### PR TITLE
Add hatchly files module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 1.4.0 (30/10/19)
+
+- Added hatchly files redirect

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
         - `css: false` so that styles aren't pulled in twice
     - `@nuxtjs/style-resources`
     - `@nuxtjs/pwa`
-    
+- Automatic 301 redirection of hatchly file URLs which are composed of only the path (e.g. in the WYSIWYG editor)
+
 ## Usage
 
 Install the dependencies using the following command:

--- a/default-options.js
+++ b/default-options.js
@@ -6,6 +6,7 @@ const defaults = {
     styleResources: true,
     snippets: true,
     navigation: true,
+    files: true,
 };
 
 const mergeDefaults = (config, hatchlyOptions) => {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const navigationModule = require('./modules/navigation/module');
 const bootstrapModule = require('./modules/bootstrap/module');
 const styleResourcesModule = require('./modules/styleResources/module');
 const snippetsModule = require('./modules/snippets/module');
+const filesModule = require('./modules/files/module');
 const genericModule = require('./modules/generic-module');
 const loader = new (require('./loader'));
 
@@ -37,6 +38,13 @@ module.exports = function HatchlyModule(options = {}) {
         loader.load(
             'navigation',
             navigationModule.call(this, options.navigation)
+        );
+    }
+
+    if (options.files) {
+        loader.load(
+            'files',
+            filesModule.call(this, options.files)
         );
     }
 

--- a/modules/files/module.js
+++ b/modules/files/module.js
@@ -1,6 +1,3 @@
-const { hasDependency } = require('../../lib/helpers');
-const { resolve } = require('path');
-
 module.exports = function filesModule(options) {
     const path = options.path || '/file';
     const host = options.host || process.env.API_URL;

--- a/modules/files/module.js
+++ b/modules/files/module.js
@@ -1,0 +1,19 @@
+const { hasDependency } = require('../../lib/helpers');
+const { resolve } = require('path');
+
+module.exports = function filesModule(options) {
+    const path = options.path || '/file';
+    const host = options.host || process.env.API_URL;
+
+    const handler = (req, res) => {
+        res.writeHead(301, {
+            Location: [host, path, req.url].join(''),
+        });
+
+        res.end();
+    };
+
+    this.addServerMiddleware({ path, handler });
+
+    return true;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@netsells/nuxt-hatchly",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "index.js",
     "license": "MIT",
     "private": false,


### PR DESCRIPTION
Adds a module which will redirect hatchly file requests which come to the FE site instead of the BE api (e.g. with the wysiwyg editor)